### PR TITLE
Unblock PyPI publishing after iqtlabs->anarkiwi transfer

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -8,6 +8,7 @@ on:
 jobs:
   release:
     runs-on: ubuntu-24.04
+    environment: release
     steps:
     - uses: actions/checkout@v6
     - name: Set up Python
@@ -26,5 +27,5 @@ jobs:
     - name: Build package
       id: build_and_publish_packages
       run: |
-        poetry publish -u ${{ secrets.PYPI_USERNAME }} -p ${{ secrets.PYPI_TOKEN }}
-      if: github.repository == 'iqtlabs/dovesnap' && github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+        poetry publish -u __token__ -p ${{ secrets.PYPI_TOKEN }}
+      if: github.repository == 'anarkiwi/dovesnap' && github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')


### PR DESCRIPTION
## Summary
- Three-in-one fix mirroring `anarkiwi/faucetconfrpc` PRs #1039 / #1040 / #1041, which addressed the same symptoms after that repo's transfer.
- After the `iqtlabs/dovesnap -> anarkiwi/dovesnap` transfer, the publish step has been silently skipped on every `v*` tag push, so PyPI has not received a release from this repo since the transfer.

What changed in `.github/workflows/pypi.yaml`:
1. Repository guard `iqtlabs/dovesnap` -> `anarkiwi/dovesnap` so `github.repository` matches and the publish step actually runs.
2. Added `environment: release` to the job so environment-scoped secrets (`PYPI_TOKEN`) are injected. Without this, an unscoped `secrets.PYPI_TOKEN` reference resolves to empty and `poetry publish` fails.
3. Auth uses literal `__token__` + `PYPI_TOKEN` instead of `PYPI_USERNAME` + `PYPI_TOKEN`. PyPI killed user/password basic-auth; `__token__` is the only valid username with an API token, so hardcoding removes a config foot-gun.

## Test plan
- [ ] Confirm `PYPI_TOKEN` exists as an **Environment secret** in the `release` environment on `anarkiwi/dovesnap` (real PyPI API token starting with `pypi-`). If it currently lives at repo level, move it to the environment.
- [ ] Push a fresh `v*` tag (or re-tag the next release).
- [ ] Verify the `release` workflow run reaches the `Build package` step, environment gate passes, and the version appears at https://pypi.org/project/dovesnap/.

🤖 Generated with [Claude Code](https://claude.com/claude-code)