### PR TITLE
Reduce nuisance workflow runs

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,5 +1,8 @@
 name: golangci-lint
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
   golangci:

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -2,7 +2,6 @@ name: release
 
 on:
   push:
-    branches: main
     tags: 'v*'
 
 jobs:
@@ -20,7 +19,7 @@ jobs:
       with:
         virtualenvs-create: false
         virtualenvs-in-project: false
-        version: 1.4.2
+        version: 1.8.3
     - name: poetry install
       run: |
        poetry build && poetry install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,9 @@
 name: test
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 env:
   POETRY_VERSION: 1.8.1


### PR DESCRIPTION
## Summary

- **release (pypi.yaml)**: drop \`branches: main\` trigger so it only fires on \`v*\` tag pushes. The publish step was already gated to tags, so the main-branch runs were pure no-op failures. Also bump Poetry 1.4.2 → 1.8.3 (1.4.2 breaks under Python 3.13 because \`distutils\` was removed — this is why every main-push release run failed).
- **test, golangci-lint**: switch \`on: [push, pull_request]\` → \`push: branches: [main]\` + \`pull_request\`, so PR commits don't fire both \`push\` and \`pull_request\` runs of the same SHA.

## Test plan

- [ ] No \`release\` run is created for the merge commit on main (only \`test\`, \`golangci-lint\`, \`buildx\` fire).
- [ ] On a follow-up PR, only one set of \`test\`/\`golangci-lint\` runs is created, not two.